### PR TITLE
Remove NLB create_before_destroy lifecycle

### DIFF
--- a/load_balancers.tf
+++ b/load_balancers.tf
@@ -192,10 +192,6 @@ resource "aws_lb" "nlb" {
       allocation_id = aws_eip.nlb[subnet_mapping.key].id
     }
   }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_lb_target_group" "nlb_tg" {


### PR DESCRIPTION
## Summary
- avoid EIP conflicts by removing the create_before_destroy lifecycle on the NLB resource

## Testing
- `terraform fmt -diff load_balancers.tf` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `bash init.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb67306864832e933417a2d15adf38